### PR TITLE
issue-4: Remove double quotes from txid response

### DIFF
--- a/handler/SubmitTransaction.go
+++ b/handler/SubmitTransaction.go
@@ -154,7 +154,7 @@ func SubmitTransaction(w http.ResponseWriter, r *http.Request) {
 			sendEnvelope(w, &utils.TransactionResponse{
 				APIVersion:                APIVersion,
 				Timestamp:                 utils.JsonTime(time.Now().UTC()),
-				TxID:                      result,
+				TxID:                      strings.Trim(result, "\""),
 				ReturnResult:              "success",
 				MinerID:                   minerID,
 				CurrentHighestBlockHash:   m["bestblockhash"].(string),


### PR DESCRIPTION
https://github.com/bitcoin-sv/merchantapi-reference/issues/4

Changes:

- Remove not needed double quote around the txid response from SubmitTransaction