### PR TITLE
Invalid JSON requires square brackets only

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,11 @@ POST /mapi/txouts?includeMempool=Boolean&returnField=confirmations
 #### Example JSON Request body
 
 ```json
-{
-  [
+[
     { "txid": "0bc1733f05aae146c3641fd...57f60f19a430ffe867020619d54800", "n": 0 },
     { "txid": "d013adf525ed5feaffc6e9d...40566470181f099f1560343cdcfd00", "n": 0 },
     { "txid": "d013adf525ed5feaffc6e9d...40566470181f099f1560343cdcfd00", "n": 1 }
-  ]
-}
-
+]
 ```
 
 ## Administrator Interface


### PR DESCRIPTION
Current example causes:
The JSON value could not be converted to MerchantAPI.APIGateway.Rest.ViewModels.TxOutsRequestViewModel[]. Path: $ | LineNumber: 0 | BytePositionInLine: 1

Remove the curly brackets.